### PR TITLE
use sub logger from the request context

### DIFF
--- a/httplog/recover.go
+++ b/httplog/recover.go
@@ -16,10 +16,10 @@ import (
 var ErrInternal = errors.New("internal error")
 
 // RecoverLogger returns a handler that call initializes Op in the context, and logs each request.
-func RecoverLogger(log zerolog.Logger) func(http.Handler) http.Handler {
+func RecoverLogger() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := log.WithContext(r.Context())
+			ctx := r.Context()
 
 			defer func() {
 				rErr := recover()

--- a/httplog/recover_test.go
+++ b/httplog/recover_test.go
@@ -24,18 +24,19 @@ func TestRecover(t *testing.T) {
 		next          http.Handler
 		wantFirstLine string
 	}{
-		{"panic String", "123", readPanic("test"), "./recover_test.go:65 (iken/httplog.readPanic.func1)"},
-		{"panic Error", "123", readPanic(errors.New("test")), "./recover_test.go:65 (iken/httplog.readPanic.func1)"},
-		{"panic other", "123", readPanic(1), "./recover_test.go:65 (iken/httplog.readPanic.func1)"},
+		{"panic String", "123", readPanic("test"), "./recover_test.go:66 (iken/httplog.readPanic.func1)"},
+		{"panic Error", "123", readPanic(errors.New("test")), "./recover_test.go:66 (iken/httplog.readPanic.func1)"},
+		{"panic other", "123", readPanic(1), "./recover_test.go:66 (iken/httplog.readPanic.func1)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logOutput := bytes.NewBuffer(nil)
 
-			h := RecoverLogger(zerolog.New(logOutput))
+			h := RecoverLogger()
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("FOO", "/BAR", bytes.NewBufferString(tt.body))
+			r = r.WithContext(logctx.NewSubLoggerContext(zerolog.New(logOutput)))
 
 			now = startNow
 			h(tt.next).ServeHTTP(w, r)


### PR DESCRIPTION
TLDR is the zerolog Logger isn't thread safe so the recover should use the sub-logger from the request context instead.