### PR TITLE
Fix: set Content-Type does not work

### DIFF
--- a/httputil/response.go
+++ b/httputil/response.go
@@ -21,8 +21,8 @@ func HTMLWrite(w http.ResponseWriter, r *http.Request, code int, data string) {
 }
 
 func Write(w http.ResponseWriter, r *http.Request, contentType string, code int, data []byte) {
-	w.WriteHeader(code)
 	w.Header().Set(ContentType, contentType)
+	w.WriteHeader(code)
 
 	if _, err := w.Write(data); err != nil {
 		ErrorHandler(w, r, err)


### PR DESCRIPTION
## Description
Currently, `JSONWrite` always responses with Content-Type of `text/plain`. After debugging, I found that the Content-Type is set after we write the header which is an issue according to [this description](https://github.com/golang/go/blob/7ad92e95b56019083824492fbec5bb07926d8ebd/src/net/http/server.go#L100-L102). This PR fixes that by changing the order of execution:
1. Set Content-Type.
2. Write Header.
3. Write Body.

