### PR TITLE
Fix content type by modifying headers prior to calling WriteHeader

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1,6 +1,7 @@
 package chain_test
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,6 +59,9 @@ func TestNew(t *testing.T) {
 func testHandler(c2 chain.Chain) string {
 	r := httptest.NewRecorder()
 	c2.Handler(http.HandlerFunc(nop)).ServeHTTP(r, nil)
-	r.Body.String()
-	return r.Body.String()
+
+	result := r.Result()
+	b, _ := io.ReadAll(result.Body)
+
+	return string(b)
 }

--- a/httputil/consts.go
+++ b/httputil/consts.go
@@ -7,4 +7,6 @@ var (
 	ApplicationJSON = "application/json"
 	// TextHTML content-type.
 	TextHTML = "text/html"
+	// TextPlain content-type.
+	TextPlain = "text/plain; charset=utf-8"
 )

--- a/httputil/errors_test.go
+++ b/httputil/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http/httptest"
 	"testing"
 
@@ -52,10 +53,12 @@ func TestErrorHandler(t *testing.T) {
 			}
 
 			httputil.ErrorHandler(w, r, test.err)
-			assert.Equal(t, test.status, w.Code, "status")
 
-			assert.Equal(t, test.body, w.Body.String(), "body")
+			result := w.Result()
+			b, _ := io.ReadAll(result.Body)
 
+			assert.Equal(t, test.status, result.StatusCode, "status")
+			assert.Equal(t, test.body, string(b), "body")
 		})
 	}
 }

--- a/httputil/response.go
+++ b/httputil/response.go
@@ -21,8 +21,8 @@ func HTMLWrite(w http.ResponseWriter, r *http.Request, code int, data string) {
 }
 
 func Write(w http.ResponseWriter, r *http.Request, contentType string, code int, data []byte) {
-	w.WriteHeader(code)
 	w.Header().Set(ContentType, contentType)
+	w.WriteHeader(code)
 
 	if _, err := w.Write(data); err != nil {
 		ErrorHandler(w, r, err)


### PR DESCRIPTION
JSONWrite/HTMLWrite/Write: returned text/plain in all cases. 

Headers were being modified after calling `WriteHeader`. 

> 	// Header returns the header map that will be sent by
> 	// WriteHeader. The Header map also is the mechanism with which
> 	// Handlers can set HTTP trailers.
> 	//
> 	// Changing the header map after a call to WriteHeader (or
> 	// Write) has no effect unless the HTTP status code was of the
> 	// 1xx class or the modified headers are trailers.

The tests weren't catching it because they were using the `ResponseRecorder` directly instead of calling `Result()` which works similar to the comment above

> // The Response.Header is a snapshot of the headers at the time of the
> // first write call, or at the time of this call, if the handler never
> // did a write.

- reordered the assert.Equal args so the expected value is on the left
- updated other tests to use the `Result()` 