### PR TITLE
httputil.JSONWrite return early on error

### DIFF
--- a/httputil/response.go
+++ b/httputil/response.go
@@ -11,6 +11,8 @@ func JSONWrite(w http.ResponseWriter, r *http.Request, code int, obj interface{}
 	b, err := json.Marshal(obj)
 	if err != nil {
 		ErrorHandler(w, r, fmt.Errorf("JSONWrite:%w", err))
+
+		return
 	}
 
 	Write(w, r, ApplicationJSON, code, b)


### PR DESCRIPTION
Ran into this error:
`http: superfluous response.WriteHeader call from github.com/bir/iken/httputil.HTTPInternalServerError (errors.go:100)`