### PR TITLE
form helpers

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ linters:
   enable-all: true
   disable:
     - execinquery
+    - exportloopref
     - gochecknoglobals
     - gomnd
     - ireturn

--- a/forms/forms.go
+++ b/forms/forms.go
@@ -1,0 +1,215 @@
+package forms
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var ErrNotFound = errors.New("not found")
+
+type File struct {
+	File     io.ReadCloser
+	Filename string
+	Header   textproto.MIMEHeader
+	Size     int64
+}
+
+func (f *File) Read(b []byte) (n int, err error) {
+	return f.File.Read(b)
+}
+
+func (f *File) Close() error {
+	if f.File == nil {
+		return nil
+	}
+
+	return f.File.Close()
+}
+
+func GetFile(r *http.Request, name string, required bool) (*File, error) {
+	file, header, err := r.FormFile(name)
+	if errors.Is(err, http.ErrMissingFile) {
+		if required {
+			return nil, fmt.Errorf("%s: %w", name, ErrNotFound)
+		} else {
+			return nil, nil
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("ToFormFile: %w", err)
+	}
+
+	if file == nil || header == nil || header.Size == 0 {
+		if required {
+			return nil, fmt.Errorf("%s: %w", name, ErrNotFound)
+		} else {
+			return nil, nil
+		}
+	}
+
+	return &File{
+		File:     file,
+		Filename: header.Filename,
+		Header:   header.Header,
+		Size:     header.Size,
+	}, nil
+}
+
+type LookupString func(key string) string
+
+func GetString(lookupString LookupString, name string, required bool) (string, error) {
+	param := lookupString(name)
+
+	if required && len(param) == 0 {
+		return "", fmt.Errorf("%s: %w", name, ErrNotFound)
+	}
+
+	return param, nil
+}
+
+func GetInt32(lookupString LookupString, name string, required bool) (int32, error) {
+	s, err := GetString(lookupString, name, required)
+	if err != nil || len(s) == 0 {
+		return 0, err
+	}
+
+	i, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid int32: %w", err)
+	}
+
+	return int32(i), nil
+}
+
+func GetInt64(lookupString LookupString, name string, required bool) (int64, error) {
+	s, err := GetString(lookupString, name, required)
+	if err != nil || len(s) == 0 {
+		return 0, err
+	}
+
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid int32: %w", err)
+	}
+
+	return i, nil
+}
+
+func GetBool(lookupString LookupString, name string, required bool) (bool, error) {
+	s, err := GetString(lookupString, name, required)
+	if err != nil || len(s) == 0 {
+		return false, err
+	}
+
+	b, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, fmt.Errorf("invalid bool: %w", err)
+	}
+
+	return b, nil
+}
+
+func GetInt(lookupString LookupString, name string, required bool) (int, error) {
+	s, err := GetString(lookupString, name, required)
+	if err != nil || len(s) == 0 {
+		return 0, err
+	}
+
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid int: %w", err)
+	}
+
+	return i, nil
+}
+
+func GetTime(lookupString LookupString, name string, required bool) (time.Time, error) {
+	s, err := GetString(lookupString, name, required)
+	if err != nil || len(s) == 0 {
+		return time.Time{}, err
+	}
+
+	timestamp, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid RFC3339 date: %w", err)
+	}
+
+	return timestamp, nil
+}
+
+func GetUUID(lookupString LookupString, name string, required bool) (uuid.UUID, error) {
+	s, err := GetString(lookupString, name, required)
+	if err != nil || len(s) == 0 {
+		return uuid.UUID{}, err
+	}
+
+	id, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("invalid uuid: %w", err)
+	}
+
+	return id, nil
+}
+
+func GetStringArray(lookupString LookupString, name string, required bool) ([]string, error) {
+	s, err := GetString(lookupString, name, required)
+	if err != nil || len(s) == 0 {
+		return nil, err
+	}
+
+	return strings.Split(s, ","), nil
+}
+
+func GetInt32Array(lookupString LookupString, name string, required bool) ([]int32, error) {
+	pp, err := GetStringArray(lookupString, name, required)
+	if err != nil || len(pp) == 0 {
+		return nil, err
+	}
+
+	out := make([]int32, len(pp))
+
+	for i, p := range pp {
+		i32, err := strconv.ParseInt(p, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid int32:%q: %w", p, err)
+		}
+
+		out[i] = int32(i32)
+	}
+
+	return out, nil
+}
+
+func GetEnum[T comparable](lookupString LookupString, name string, required bool, parser func(string) T) (T, error) {
+	var out T
+
+	s, err := GetString(lookupString, name, required)
+	if err != nil || len(s) == 0 {
+		return out, err
+	}
+
+	return parser(s), nil
+}
+
+func GetEnumArray[T comparable](lookupString LookupString, name string, required bool, parser func(string) T) ([]T, error) {
+	pp, err := GetStringArray(lookupString, name, required)
+	if err != nil || len(pp) == 0 {
+		return nil, err
+	}
+
+	out := make([]T, len(pp))
+
+	for i, p := range pp {
+		out[i] = parser(p)
+	}
+
+	return out, nil
+}

--- a/forms/forms.go
+++ b/forms/forms.go
@@ -36,14 +36,6 @@ func GetFile(r *http.Request, name string, required bool) (File, bool, error) {
 		return File{}, false, fmt.Errorf("ToFormFile: %w", err)
 	}
 
-	if file == nil || header == nil || header.Size == 0 {
-		if required {
-			return File{}, false, fmt.Errorf("%s: %w", name, ErrNotFound)
-		}
-
-		return File{}, false, nil
-	}
-
 	return File{
 		File:     file,
 		Filename: header.Filename,

--- a/forms/forms_test.go
+++ b/forms/forms_test.go
@@ -1,0 +1,442 @@
+package forms
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFile(t *testing.T) {
+	const expectedKey = "foo"
+	const expectedContent = "123"
+	const expectedFilename = "test.txt"
+
+	newRequest := func(notMultipart bool) (*http.Request, error) {
+		if notMultipart {
+			return http.NewRequest("GET", "/ping", nil)
+		}
+
+		var data bytes.Buffer
+		w := multipart.NewWriter(&data)
+
+		fw, err := w.CreateFormFile(expectedKey, expectedFilename)
+		if err != nil {
+			return nil, fmt.Errorf("error creating field: %w", err)
+		}
+
+		_, err = io.Copy(fw, strings.NewReader(expectedContent))
+		if err != nil {
+			return nil, fmt.Errorf("error copying value for field: %w", err)
+		}
+
+		err = w.Close()
+		if err != nil {
+			return nil, fmt.Errorf("error closing writer: for field: %w", err)
+		}
+
+		req := httptest.NewRequest("POST", "/ping", &data)
+		req.Header.Set("Content-Type", w.FormDataContentType())
+
+		return req, nil
+	}
+
+	tests := []struct {
+		name         string
+		key          string
+		notMultipart bool
+		required     bool
+		want         string
+		errMsg       string
+	}{
+		{name: " required present", key: "foo", required: true, want: "123"},
+		{name: " required missing", key: "foo2", required: true, errMsg: ErrNotFound.Error()},
+		{name: " not required present", key: "foo", want: "123"},
+		{name: " not required missing", key: "foo2"},
+		{name: " not multipart", key: "foo", notMultipart: true, errMsg: "ToFormFile: request Content-Type isn't multipart/form-data"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := newRequest(tt.notMultipart)
+			assert.NoError(t, err)
+
+			f, err := GetFile(r, tt.key, tt.required)
+			if tt.errMsg != "" {
+				assert.ErrorContains(t, err, tt.errMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if f != nil {
+				defer f.Close()
+			}
+
+			if tt.want == "" {
+				assert.Nil(t, f)
+				return
+			}
+
+			assert.Equal(t, expectedFilename, f.Filename)
+			assert.Equal(t, int64(len(expectedContent)), f.Size)
+
+			buf := new(strings.Builder)
+			_, err = io.Copy(buf, f.File)
+			assert.NoError(t, err)
+			assert.Equal(t, len(expectedContent), len(buf.String()))
+			assert.Equal(t, tt.want, buf.String())
+		})
+	}
+}
+
+func TestGetString(t *testing.T) {
+	newFormRequest := func(key, value string) *http.Request {
+		var data string
+		if key != "" {
+			data = url.Values{key: []string{value}}.Encode()
+		}
+
+		req := httptest.NewRequest("POST", "/ping", strings.NewReader(data))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		return req
+	}
+
+	newMultipartRequest := func(key, value string) (*http.Request, error) {
+		contentType := "multipart/form-data"
+
+		var c int64
+		var data bytes.Buffer
+		if key != "" {
+			w := multipart.NewWriter(&data)
+
+			fw, err := w.CreateFormField(key)
+			if err != nil {
+				return nil, fmt.Errorf("error creating field: %s: %w", key, err)
+			}
+
+			c, err = io.Copy(fw, strings.NewReader(value))
+			if err != nil {
+				return nil, fmt.Errorf("error copying value for field: %s: %w", key, err)
+			}
+
+			err = w.Close()
+			if err != nil {
+				return nil, fmt.Errorf("error closing writer: for field: %s: %w", key, err)
+			}
+
+			contentType = w.FormDataContentType()
+		}
+
+		req := httptest.NewRequest("POST", "/ping", &data)
+		req.Header.Set("Content-Type", contentType)
+
+		fmt.Printf("request: %v: %v", c, req)
+
+		return req, nil
+	}
+
+	tests := []struct {
+		name     string
+		key      string
+		value    string
+		form     string
+		required bool
+		want     string
+		wantErr  bool
+	}{
+		{" required present", "foo", "123", "foo", true, "123", false},
+		{" required missing", "", "", "foo", true, "", true},
+		{" not required present", "foo", "123", "foo", false, "123", false},
+		{" not required missing", "", "", "foo", false, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Verify that GetString returns data from each of the FormValue sources:
+			//  1. application/x-www-form-urlencoded form body (POST, PUT, PATCH only)
+			//  2. query parameters (always)
+			//  3. multipart/form-data form body (always)
+			var params string
+			if tt.key != "" {
+				params = fmt.Sprintf("?%s=%s", tt.key, tt.value)
+			}
+
+			r := httptest.NewRequest("POST", "/BAR"+params, nil)
+
+			got, err := GetString(r.FormValue, tt.form, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+
+			r = newFormRequest(tt.key, tt.value)
+
+			got, err = GetString(r.FormValue, tt.form, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+
+			r, err = newMultipartRequest(tt.key, tt.value)
+			assert.NoError(t, err)
+
+			got, err = GetString(r.FormValue, tt.form, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+func TestGetInt32(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     int32
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", true, 123, false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, 0, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, 0, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", true, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetInt32(tt.r.FormValue, tt.param, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+func TestGetInt(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     int
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", true, 123, false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, 0, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, 0, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", true, 0, true},
+		{"max", httptest.NewRequest("GET", "/BAR?foo=9223372036854775807", nil), "foo", true, 9223372036854775807, false},
+		{"over max", httptest.NewRequest("GET", "/BAR?foo=19223372036854775807", nil), "foo", true, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetInt(tt.r.FormValue, tt.param, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+func TestGetInt64(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     int64
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", true, 123, false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, 0, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, 0, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", true, 0, true},
+		{"max", httptest.NewRequest("GET", "/BAR?foo=9223372036854775807", nil), "foo", true, 9223372036854775807, false},
+		{"over max", httptest.NewRequest("GET", "/BAR?foo=19223372036854775807", nil), "foo", true, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetInt64(tt.r.FormValue, tt.param, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+func TestGetBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     bool
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=true", nil), "foo", true, true, false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, false, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, false, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", true, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetBool(tt.r.FormValue, tt.param, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+func TestGetInt32Array(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     []int32
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", true, []int32{123}, false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, nil, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, nil, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", true, nil, true},
+		{"large", httptest.NewRequest("GET", "/BAR?foo=1,2,3,4", nil), "foo", true, []int32{1, 2, 3, 4}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetInt32Array(tt.r.FormValue, tt.param, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+func TestGetTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     time.Time
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=2006-01-02T15:04:05Z", nil), "foo", true, time.Date(2006, 0o1, 0o2, 15, 4, 5, 0, time.UTC), false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, time.Time{}, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, time.Time{}, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=200601021504050700", nil), "foo", true, time.Time{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetTime(tt.r.FormValue, tt.param, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+func TestGetUUID(t *testing.T) {
+	testUUID, _ := uuid.Parse("48ab873f-d4fc-4e2b-bf92-9440e431ff54")
+
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     uuid.UUID
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=48ab873f-d4fc-4e2b-bf92-9440e431ff54", nil), "foo", true, testUUID, false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, uuid.UUID{}, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, uuid.UUID{}, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", true, uuid.UUID{}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetUUID(tt.r.FormValue, tt.param, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+type TestEnum int8
+
+const (
+	testEnumUnknown TestEnum = iota
+	testEnumA
+	testEnumB
+	testEnumC
+)
+
+func NewTestEnum(name string) TestEnum {
+	switch name {
+	case "aaa":
+		return testEnumA
+	case "bbb":
+		return testEnumB
+	case "ccc":
+		return testEnumC
+	}
+
+	return TestEnum(0)
+}
+
+func TestGetEnum(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     TestEnum
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=bbb", nil), "foo", true, testEnumB, false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, testEnumUnknown, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, testEnumUnknown, false},
+		{"bad value", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", true, testEnumUnknown, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetEnum(tt.r.FormValue, tt.param, tt.required, NewTestEnum)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}
+
+func TestGetEnumArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		required bool
+		want     []TestEnum
+		wantErr  bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=bbb", nil), "foo", true, []TestEnum{testEnumB}, false},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", true, nil, true},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", false, nil, false},
+		{"bad value", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", true, []TestEnum{testEnumUnknown}, false},
+		{"all", httptest.NewRequest("GET", "/BAR?foo=aaa,bbb,ccc", nil), "foo", true, []TestEnum{testEnumA, testEnumB, testEnumC}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetEnumArray(tt.r.FormValue, tt.param, tt.required, NewTestEnum)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+		})
+	}
+}

--- a/forms/forms_test.go
+++ b/forms/forms_test.go
@@ -82,7 +82,10 @@ func TestGetFile(t *testing.T) {
 			}
 
 			if tt.want == "" {
-				assert.Nil(t, f)
+				assert.False(t, ok)
+				assert.Nil(t, f.File)
+				assert.Zero(t, f.Size)
+				assert.Empty(t, f.Filename)
 				return
 			}
 

--- a/forms/forms_test.go
+++ b/forms/forms_test.go
@@ -69,7 +69,7 @@ func TestGetFile(t *testing.T) {
 			r, err := newRequest(tt.notMultipart)
 			assert.NoError(t, err)
 
-			f, err := GetFile(r, tt.key, tt.required)
+			f, ok, err := GetFile(r, tt.key, tt.required)
 			if tt.errMsg != "" {
 				assert.ErrorContains(t, err, tt.errMsg)
 				return
@@ -77,8 +77,8 @@ func TestGetFile(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			if f != nil {
-				defer f.Close()
+			if ok {
+				defer f.File.Close()
 			}
 
 			if tt.want == "" {


### PR DESCRIPTION
Similar to the helpers in the params package

The string based variants take in a function instead of calling `FormValue` on the request directly to make it easier to extend to other calls like `PathValue`