### PR TITLE
params: Add GetType{Path,Query,Header,Cookie} param functions

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -451,7 +451,7 @@ func GetInt32Array(r *http.Request, name string, required bool) ([]int32, bool, 
 	return convertInt32Array(pp)
 }
 
-func GetInt32ArraPath(r *http.Request, name string, required bool) ([]int32, bool, error) {
+func GetInt32ArrayPath(r *http.Request, name string, required bool) ([]int32, bool, error) {
 	pp, ok, err := GetStringArrayPath(r, name, required)
 	if err != nil || len(pp) == 0 || !ok {
 		return nil, false, err

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -320,3 +320,301 @@ func TestGetEnumArray(t *testing.T) {
 		})
 	}
 }
+func TestGetStringFrom(t *testing.T) {
+	newHeaderRequest := func(key, value string) *http.Request {
+		r := httptest.NewRequest("GET", "/ping", nil)
+		if key != "" {
+			r.Header.Set(key, value)
+		}
+
+		return r
+	}
+
+	newMultiSourceRequest := func(key string) *http.Request {
+		r := httptest.NewRequest("GET", "/ping?"+key+"=queryval", nil)
+		r.Header.Set(key, "headerval")
+		r.AddCookie(&http.Cookie{Name: key, Value: "cookieval"})
+		r.SetPathValue(key, "pathval")
+		return r
+	}
+
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     string
+		wantErr  bool
+		wantOk   bool
+	}{
+		{" header required present", newHeaderRequest("foo", "123"), "foo", ParamHeader, true, "123", false, true},
+		{" header required missing", newHeaderRequest("", ""), "foo", ParamHeader, true, "", true, false},
+		{" header not required present", newHeaderRequest("foo", "123"), "foo", ParamHeader, false, "123", false, true},
+		{" header not required missing", newHeaderRequest("", ""), "foo", ParamHeader, false, "", false, false},
+		{" fetch header specifically", newMultiSourceRequest("foo"), "foo", ParamHeader, false, "headerval", false, true},
+		{" fetch query specifically", newMultiSourceRequest("foo"), "foo", ParamQuery, false, "queryval", false, true},
+		{" fetch cookie specifically", newMultiSourceRequest("foo"), "foo", ParamCookie, false, "cookieval", false, true},
+		{" fetch cookie specifically", newMultiSourceRequest("foo"), "foo", ParamPath, false, "pathval", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetStringFrom(tt.r, tt.param, tt.source, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetInt32From(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     int32
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", ParamQuery, true, 123, false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, 0, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, 0, false, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", ParamQuery, true, 0, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetInt32From(tt.r, tt.param, tt.source, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetIntFrom(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     int
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", ParamQuery, true, 123, false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, 0, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, 0, false, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", ParamQuery, true, 0, true, false},
+		{"max", httptest.NewRequest("GET", "/BAR?foo=9223372036854775807", nil), "foo", ParamQuery, true, 9223372036854775807, false, true},
+		{"over max", httptest.NewRequest("GET", "/BAR?foo=19223372036854775807", nil), "foo", ParamQuery, true, 0, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetIntFrom(tt.r, tt.param, tt.source, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetInt64From(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     int64
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", ParamQuery, true, 123, false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, 0, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, 0, false, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", ParamQuery, true, 0, true, false},
+		{"max", httptest.NewRequest("GET", "/BAR?foo=9223372036854775807", nil), "foo", ParamQuery, true, 9223372036854775807, false, true},
+		{"over max", httptest.NewRequest("GET", "/BAR?foo=19223372036854775807", nil), "foo", ParamQuery, true, 0, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetInt64From(tt.r, tt.param, tt.source, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetBoolFrom(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     bool
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=true", nil), "foo", ParamQuery, true, true, false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, false, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, false, false, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", ParamQuery, true, false, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetBoolFrom(tt.r, tt.param, tt.source, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetInt32ArrayFrom(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     []int32
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", ParamQuery, true, []int32{123}, false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, nil, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, nil, false, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", ParamQuery, true, nil, true, false},
+		{"large", httptest.NewRequest("GET", "/BAR?foo=1,2,3,4", nil), "foo", ParamQuery, true, []int32{1, 2, 3, 4}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetInt32ArrayFrom(tt.r, tt.param, tt.source, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetTimeFrom(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     time.Time
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=2006-01-02T15:04:05Z", nil), "foo", ParamQuery, true, time.Date(2006, 0o1, 0o2, 15, 4, 5, 0, time.UTC), false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, time.Time{}, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, time.Time{}, false, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=200601021504050700", nil), "foo", ParamQuery, true, time.Time{}, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetTimeFrom(tt.r, tt.param, tt.source, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetUUIDFrom(t *testing.T) {
+	testUUID, _ := uuid.Parse("48ab873f-d4fc-4e2b-bf92-9440e431ff54")
+
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     uuid.UUID
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=48ab873f-d4fc-4e2b-bf92-9440e431ff54", nil), "foo", ParamQuery, true, testUUID, false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, uuid.UUID{}, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, uuid.UUID{}, false, false},
+		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", ParamQuery, true, uuid.UUID{}, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetUUIDFrom(tt.r, tt.param, tt.source, tt.required)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetEnumFrom(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     TestEnum
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=bbb", nil), "foo", ParamQuery, true, testEnumB, false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, testEnumUnknown, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, testEnumUnknown, false, false},
+		{"bad value", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", ParamQuery, true, testEnumUnknown, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetEnumFrom(tt.r, tt.param, tt.source, tt.required, NewTestEnum)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}
+
+func TestGetEnumArrayFrom(t *testing.T) {
+	tests := []struct {
+		name     string
+		r        *http.Request
+		param    string
+		source   ParamSource
+		required bool
+		want     []TestEnum
+		wantErr  bool
+		wantOk   bool
+	}{
+		{"simple", httptest.NewRequest("GET", "/BAR?foo=bbb", nil), "foo", ParamQuery, true, []TestEnum{testEnumB}, false, true},
+		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", ParamQuery, true, nil, true, false},
+		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", ParamQuery, false, nil, false, false},
+		{"bad value", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", ParamQuery, true, []TestEnum{testEnumUnknown}, false, true},
+		{"all", httptest.NewRequest("GET", "/BAR?foo=aaa,bbb,ccc", nil), "foo", ParamQuery, true, []TestEnum{testEnumA, testEnumB, testEnumC}, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := GetEnumArrayFrom(tt.r, tt.param, tt.source, tt.required, NewTestEnum)
+
+			assert.Equal(t, tt.wantErr, err != nil, "error")
+			assert.Equal(t, tt.want, got, "value")
+			assert.Equal(t, tt.wantOk, ok, "ok")
+		})
+	}
+}

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -10,6 +10,37 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func NewQueryRequest(method, target, key, value string) *http.Request {
+	r := httptest.NewRequest(method, target+"?"+key+"="+value, nil)
+	return r
+}
+
+func NewPathRequest(method, target, key, value string) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	r.SetPathValue(key, value)
+	return r
+}
+
+func NewHeaderRequest(method, target, key, value string) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	r.Header.Add(key, value)
+	return r
+}
+
+func NewCookieRequest(method, target, key, value string) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	r.AddCookie(&http.Cookie{Name: key, Value: value})
+	return r
+}
+
+func NewMultiSourceRequest(method, target, key string, values [4]string) *http.Request {
+	r := httptest.NewRequest(method, target+"?"+key+"="+values[ParamSourceQuery], nil)
+	r.Header.Set(key, values[ParamSourceHeader])
+	r.AddCookie(&http.Cookie{Name: key, Value: values[ParamSourceCookie]})
+	r.SetPathValue(key, values[ParamSourcePath])
+	return r
+}
+
 func TestGetString(t *testing.T) {
 	newHeaderRequest := func(key, value string) *http.Request {
 		r := httptest.NewRequest("GET", "/ping", nil)
@@ -320,321 +351,311 @@ func TestGetEnumArray(t *testing.T) {
 		})
 	}
 }
-func TestGetStringFrom(t *testing.T) {
-	newHeaderRequest := func(key, value string) *http.Request {
-		r := httptest.NewRequest("GET", "/ping", nil)
-		if key != "" {
-			r.Header.Set(key, value)
-		}
 
-		return r
-	}
+type ParamSource int
 
-	newMultiSourceRequest := func(key string) *http.Request {
-		r := httptest.NewRequest("GET", "/ping?"+key+"=queryval", nil)
-		r.Header.Set(key, "headerval")
-		r.AddCookie(&http.Cookie{Name: key, Value: "cookieval"})
-		r.SetPathValue(key, "pathval")
-		return r
-	}
+const (
+	ParamSourcePath ParamSource = iota
+	ParamSourceQuery
+	ParamSourceHeader
+	ParamSourceCookie
+)
 
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
+var ParamSources = []ParamSource{ParamSourcePath, ParamSourceQuery, ParamSourceHeader, ParamSourceCookie}
+var ParamSourceNames = []string{"Path", "Query", "Header", "Cookie"}
 
-		method func(r *http.Request, name string, required bool) (string, bool, error)
-
-		required bool
-		want     string
-		wantErr  bool
-		wantOk   bool
-	}{
-		{" header required present", newHeaderRequest("foo", "123"), "foo", GetStringHeader, true, "123", false, true},
-		{" header required missing", newHeaderRequest("", ""), "foo", GetStringHeader, true, "", true, false},
-		{" header not required present", newHeaderRequest("foo", "123"), "foo", GetStringHeader, false, "123", false, true},
-		{" header not required missing", newHeaderRequest("", ""), "foo", GetStringHeader, false, "", false, false},
-		{" fetch header specifically", newMultiSourceRequest("foo"), "foo", GetStringHeader, false, "headerval", false, true},
-		{" fetch query specifically", newMultiSourceRequest("foo"), "foo", GetStringQuery, false, "queryval", false, true},
-		{" fetch cookie specifically", newMultiSourceRequest("foo"), "foo", GetStringCookie, false, "cookieval", false, true},
-		{" fetch path specifically", newMultiSourceRequest("foo"), "foo", GetStringPath, false, "pathval", false, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
-
-func TestGetInt32From(t *testing.T) {
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
-
-		method func(r *http.Request, name string, required bool) (int32, bool, error)
-
-		required bool
-		want     int32
-		wantErr  bool
-		wantOk   bool
-	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", GetInt32Query, true, 123, false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetInt32Query, true, 0, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetInt32Query, false, 0, false, false},
-		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", GetInt32Query, true, 0, true, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
-
-func TestGetIntFrom(t *testing.T) {
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
-
-		method func(r *http.Request, name string, required bool) (int, bool, error)
-
-		required bool
-		want     int
-		wantErr  bool
-		wantOk   bool
-	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", GetIntQuery, true, 123, false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetIntQuery, true, 0, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetIntQuery, false, 0, false, false},
-		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", GetIntQuery, true, 0, true, false},
-		{"max", httptest.NewRequest("GET", "/BAR?foo=9223372036854775807", nil), "foo", GetIntQuery, true, 9223372036854775807, false, true},
-		{"over max", httptest.NewRequest("GET", "/BAR?foo=19223372036854775807", nil), "foo", GetIntQuery, true, 0, true, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
-
-func TestGetInt64From(t *testing.T) {
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
-
-		method func(r *http.Request, name string, required bool) (int64, bool, error)
-
-		required bool
-		want     int64
-		wantErr  bool
-		wantOk   bool
-	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", GetInt64Query, true, 123, false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetInt64Query, true, 0, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetInt64Query, false, 0, false, false},
-		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", GetInt64Query, true, 0, true, false},
-		{"max", httptest.NewRequest("GET", "/BAR?foo=9223372036854775807", nil), "foo", GetInt64Query, true, 9223372036854775807, false, true},
-		{"over max", httptest.NewRequest("GET", "/BAR?foo=19223372036854775807", nil), "foo", GetInt64Query, true, 0, true, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
-
-func TestGetBoolFrom(t *testing.T) {
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
-
-		method func(r *http.Request, name string, required bool) (bool, bool, error)
-
-		required bool
-		want     bool
-		wantErr  bool
-		wantOk   bool
-	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=true", nil), "foo", GetBoolQuery, true, true, false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetBoolQuery, true, false, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetBoolQuery, false, false, false, false},
-		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", GetBoolQuery, true, false, true, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
-
-func TestGetInt32ArrayFrom(t *testing.T) {
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
-
-		method func(r *http.Request, name string, required bool) ([]int32, bool, error)
-
-		required bool
-		want     []int32
-		wantErr  bool
-		wantOk   bool
-	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=123", nil), "foo", GetInt32ArrayQuery, true, []int32{123}, false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetInt32ArrayQuery, true, nil, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetInt32ArrayQuery, false, nil, false, false},
-		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", GetInt32ArrayQuery, true, nil, true, false},
-		{"large", httptest.NewRequest("GET", "/BAR?foo=1,2,3,4", nil), "foo", GetInt32ArrayQuery, true, []int32{1, 2, 3, 4}, false, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
-
-func TestGetTimeFrom(t *testing.T) {
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
-
-		method func(r *http.Request, name string, required bool) (time.Time, bool, error)
-
-		required bool
-		want     time.Time
-		wantErr  bool
-		wantOk   bool
-	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=2006-01-02T15:04:05Z", nil), "foo", GetTimeQuery, true, time.Date(2006, 0o1, 0o2, 15, 4, 5, 0, time.UTC), false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetTimeQuery, true, time.Time{}, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetTimeQuery, false, time.Time{}, false, false},
-		{"bad format", httptest.NewRequest("GET", "/BAR?foo=200601021504050700", nil), "foo", GetTimeQuery, true, time.Time{}, true, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
-
-func TestGetUUIDFrom(t *testing.T) {
+// This abomination of a test function exists to run the same tests against all the different types
+// that can be retrieved from a param and all the different ways a param can be passed. The
+// ugliness in typeList and everything downstream of that is necessary to get the polymorpism
+// required to run against different types.
+func TestMatrix(t *testing.T) {
 	testUUID, _ := uuid.Parse("48ab873f-d4fc-4e2b-bf92-9440e431ff54")
+	RequestFunctions := map[ParamSource]func(method string, target string, key string, value string) *http.Request{
+		ParamSourcePath:   NewPathRequest,
+		ParamSourceQuery:  NewQueryRequest,
+		ParamSourceHeader: NewHeaderRequest,
+		ParamSourceCookie: NewCookieRequest,
+	}
 
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
-
-		method func(r *http.Request, name string, required bool) (uuid.UUID, bool, error)
-
-		required bool
-		want     uuid.UUID
-		wantErr  bool
-		wantOk   bool
+	typeList := []struct {
+		Name              string
+		TestValue         any
+		TestValueAsString string
+		// Go does not allow you to pass a func() something as a func() any, so wrappers will be needed :(
+		Methods map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error)
 	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=48ab873f-d4fc-4e2b-bf92-9440e431ff54", nil), "foo", GetUUIDQuery, true, testUUID, false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetUUIDQuery, true, uuid.UUID{}, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetUUIDQuery, false, uuid.UUID{}, false, false},
-		{"bad format", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", GetUUIDQuery, true, uuid.UUID{}, true, false},
+		{
+			Name:              "String",
+			TestValue:         "foo",
+			TestValueAsString: "foo",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetStringPath(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetStringQuery(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetStringHeader(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetStringCookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "Int",
+			TestValue:         123,
+			TestValueAsString: "123",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetIntPath(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetIntQuery(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetIntHeader(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetIntCookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "Int32",
+			TestValue:         int32(123),
+			TestValueAsString: "123",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt32Path(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt32Query(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt32Header(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt32Cookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "Int64",
+			TestValue:         int64(123),
+			TestValueAsString: "123",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt64Path(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt64Query(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt64Header(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt64Cookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "Bool",
+			TestValue:         true,
+			TestValueAsString: "true",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetBoolPath(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetBoolQuery(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetBoolHeader(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetBoolCookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "Time",
+			TestValue:         time.Date(2006, 0o1, 0o2, 15, 4, 5, 0, time.UTC),
+			TestValueAsString: "2006-01-02T15:04:05Z",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetTimePath(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetTimeQuery(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetTimeHeader(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetTimeCookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "UUID",
+			TestValue:         testUUID,
+			TestValueAsString: "48ab873f-d4fc-4e2b-bf92-9440e431ff54",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetUUIDPath(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetUUIDQuery(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetUUIDHeader(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetUUIDCookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "Enum",
+			TestValue:         testEnumA,
+			TestValueAsString: "aaa",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetEnumPath(r, name, required, NewTestEnum)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetEnumQuery(r, name, required, NewTestEnum)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetEnumHeader(r, name, required, NewTestEnum)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetEnumCookie(r, name, required, NewTestEnum)
+				},
+			},
+		},
+		{
+			Name:              "StringArray",
+			TestValue:         []string{"a", "b"},
+			TestValueAsString: "a,b",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetStringArrayPath(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetStringArrayQuery(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetStringArrayHeader(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetStringArrayCookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "Int32Array",
+			TestValue:         []int32{123, 456},
+			TestValueAsString: "123,456",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt32ArrayPath(r, name, required)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt32ArrayQuery(r, name, required)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt32ArrayHeader(r, name, required)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetInt32ArrayCookie(r, name, required)
+				},
+			},
+		},
+		{
+			Name:              "EnumArray",
+			TestValue:         []TestEnum{testEnumA, testEnumB},
+			TestValueAsString: "aaa,bbb",
+			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
+				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetEnumArrayPath(r, name, required, NewTestEnum)
+				},
+				ParamSourceQuery: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetEnumArrayQuery(r, name, required, NewTestEnum)
+				},
+				ParamSourceHeader: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetEnumArrayHeader(r, name, required, NewTestEnum)
+				},
+				ParamSourceCookie: func(r *http.Request, name string, required bool) (any, bool, error) {
+					return GetEnumArrayCookie(r, name, required, NewTestEnum)
+				},
+			},
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required)
 
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
+	for _, typeInfo := range typeList {
+		for _, source := range ParamSources {
+			multiSourceValues := [4]string{"a", "b", "c", "d"}
+			multiSourceValues[source] = typeInfo.TestValueAsString
 
-func TestGetEnumFrom(t *testing.T) {
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
+			perTypeTests := []struct {
+				Name     string
+				Request  *http.Request
+				Required bool
+				Want     any
+				WantErr  bool
+				WantOk   bool
+				Method   func(r *http.Request, name string, required bool) (any, bool, error)
+			}{
+				{
+					Name:     "required present",
+					Request:  RequestFunctions[source]("GET", "/BAR", "foo", typeInfo.TestValueAsString),
+					Method:   typeInfo.Methods[source],
+					Required: true,
+					Want:     typeInfo.TestValue,
+					WantOk:   true,
+				},
+				{
+					Name:     "required missing",
+					Request:  RequestFunctions[source]("GET", "/BAR", "", ""),
+					Method:   typeInfo.Methods[source],
+					Required: true,
+					WantErr:  true,
+				},
+				{
+					Name:     "optional missing",
+					Request:  RequestFunctions[source]("GET", "/BAR", "", ""),
+					Method:   typeInfo.Methods[source],
+					Required: false,
+					WantOk:   false,
+				},
+				{
+					Name:    "ignore other sources",
+					Request: NewMultiSourceRequest("GET", "/BAR", "foo", multiSourceValues),
+					Method:  typeInfo.Methods[source],
+					Want:    typeInfo.TestValue,
+					WantOk:  true,
+				},
+			}
 
-		method func(r *http.Request, name string, required bool, parser func(string) TestEnum) (TestEnum, bool, error)
+			for _, tt := range perTypeTests {
+				t.Run("Get"+typeInfo.Name+ParamSourceNames[source]+"_"+tt.Name, func(t *testing.T) {
+					got, ok, err := tt.Method(tt.Request, "foo", tt.Required)
 
-		required bool
-		want     TestEnum
-		wantErr  bool
-		wantOk   bool
-	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=bbb", nil), "foo", GetEnumQuery[TestEnum], true, testEnumB, false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetEnumQuery[TestEnum], true, testEnumUnknown, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetEnumQuery[TestEnum], false, testEnumUnknown, false, false},
-		{"bad value", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", GetEnumQuery[TestEnum], true, testEnumUnknown, false, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required, NewTestEnum)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
-	}
-}
-
-func TestGetEnumArrayFrom(t *testing.T) {
-	tests := []struct {
-		name  string
-		r     *http.Request
-		param string
-
-		method func(r *http.Request, name string, required bool, parser func(string) TestEnum) ([]TestEnum, bool, error)
-
-		required bool
-		want     []TestEnum
-		wantErr  bool
-		wantOk   bool
-	}{
-		{"simple", httptest.NewRequest("GET", "/BAR?foo=bbb", nil), "foo", GetEnumArrayQuery[TestEnum], true, []TestEnum{testEnumB}, false, true},
-		{"required missing", httptest.NewRequest("GET", "/BAR", nil), "foo", GetEnumArrayQuery[TestEnum], true, nil, true, false},
-		{"not required missing", httptest.NewRequest("GET", "/BAR?", nil), "foo", GetEnumArrayQuery[TestEnum], false, nil, false, false},
-		{"bad value", httptest.NewRequest("GET", "/BAR?foo=a123", nil), "foo", GetEnumArrayQuery[TestEnum], true, []TestEnum{testEnumUnknown}, false, true},
-		{"all", httptest.NewRequest("GET", "/BAR?foo=aaa,bbb,ccc", nil), "foo", GetEnumArrayQuery[TestEnum], true, []TestEnum{testEnumA, testEnumB, testEnumC}, false, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := tt.method(tt.r, tt.param, tt.required, NewTestEnum)
-
-			assert.Equal(t, tt.wantErr, err != nil, "error")
-			assert.Equal(t, tt.want, got, "value")
-			assert.Equal(t, tt.wantOk, ok, "ok")
-		})
+					if tt.WantErr {
+						assert.Error(t, err)
+					} else if tt.WantOk {
+						assert.NoError(t, err)
+						assert.True(t, ok)
+						assert.Equal(t, tt.Want, got)
+					} else {
+						assert.NoError(t, err)
+						assert.False(t, ok)
+					}
+				})
+			}
+		}
 	}
 }


### PR DESCRIPTION
Currently params.Get* will look for a parameter in the request path values, query string and Headers in that order. There is no way to be specific in what kind of parameter you want to fetch.

This commit adds two new features:

* params.Get*From functions, which take an extra source parameter that allows you to specific which location you want to get a parameter from, with no fallback.

* Cookie support (in the Get*From functions only).

This is motivated by a desire to support Cookies in gofoji's openapi request parsing, but to do so without accidentally leaking cookies into any existing users of the param package. See https://github.com/gofoji/foji/commit/2ea146209779d5fb4a8d23d662f2d7968fc41aa2 for how this will be used.