### PR TITLE
params: ignore commas if not working with arrays

### DIFF
--- a/params/params_test.go
+++ b/params/params_test.go
@@ -419,8 +419,8 @@ func TestMatrix(t *testing.T) {
 	}{
 		{
 			Name:              "String",
-			TestValue:         "foo",
-			TestValueAsString: "foo",
+			TestValue:         "foo,bar",
+			TestValueAsString: "foo,bar",
 			Methods: map[ParamSource]func(r *http.Request, name string, required bool) (any, bool, error){
 				ParamSourcePath: func(r *http.Request, name string, required bool) (any, bool, error) {
 					return GetStringPath(r, name, required)


### PR DESCRIPTION
The previous setup broke callers that were looking for a single value that happened to have a comma in it.