### PR TITLE
Add client helper methods, errors and auth types for future foji client generator

### DIFF
--- a/currency/fixed_format.go
+++ b/currency/fixed_format.go
@@ -78,7 +78,7 @@ func (cf FixedFormatter) formatFractionalPart(fractionalPart int64) string {
 	offset := Power10(cf.precision) / cf.factor
 
 	for offset > 1 {
-		fractionalStr += "0" //nolint:perfsprint
+		fractionalStr += "0" //nolint:perfsprint,modernize
 		offset /= base
 	}
 

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -29,6 +29,8 @@ const (
 	// ErrMissingAuthorizer is caused by internal configuration errors when evaluating authorization.
 	ErrMissingAuthorizer = AuthError("missing authenticator")
 
+	ErrCouldntAuthenticate = AuthError("could not authenticate request")
+
 	// BasicAuthPrefix as defined by https://datatracker.ietf.org/doc/html/rfc7617
 	BasicAuthPrefix = "Basic "
 
@@ -53,23 +55,28 @@ type TokenAuthenticatorFunc[T any] func(ctx context.Context, token string) (T, e
 type BasicAuthenticatorFunc[T any] func(ctx context.Context, user, pass string) (T, error)
 
 // ClientAuthenticateFunc is the signature of a function used to add authentication to an outbound HTTP request.
-// It also has an opportunity to wrap the httpClient to be used for the request.
+// It also has an opportunity to wrap the httpClient to be used for the request. Should return [ErrCouldntAuthenticate]
+// if the method was not able to provide authorization for this user.
 type ClientAuthenticateFunc[T any] func(r *http.Request, innerClient *http.Client, user T) (*http.Client, error)
 
 // ClientTokenAuthenticatorFunc is the signature of a function used to determine the token that should be added
-// to an outbound HTTP request as authentication.
+// to an outbound HTTP request as authentication. Should return [ErrCouldntAuthenticate] if the method was not able to
+// provide authorization for this user.
 type ClientTokenAuthenticatorFunc[T any] func(ctx context.Context, user T) (string, error)
 
 // ClientBasicAuthenticatorFunc is the signature of a function used to determine the username and password
-// that should be used to add Bsaic authentication to an outbound HTTP request.
+// that should be used to add Bsaic authentication to an outbound HTTP request. Should return [ErrCouldntAuthenticate]
+// if the method was not able to provide authorization for this user.
 type ClientBasicAuthenticatorFunc[T any] func(ctx context.Context, user T) (string, string, error)
 
-// ClientCookieAuthenticatorFunc is the signature of a function used to determine the cookie
-// that should be added to an outbound HTTP request.
+// ClientCookieAuthenticatorFunc is the signature of a function used to determine the cookie that should be added
+// to an outbound HTTP request.  Should return [ErrCouldntAuthenticate] if the method was not able to provide
+// authorization for this user.
 type ClientCookieAuthenticatorFunc[T any] func(ctx context.Context, user T) (*http.Cookie, error)
 
 // ClientWrappingAuthenticatorFunc is the signature of a function used to wrap an http client so that it will
-// add authentication. This is intended for integration with x/oauth2.
+// add authentication. This is intended for integration with x/oauth2.  Should return [ErrCouldntAuthenticate] if the
+// method was not able to provide authorization for this user.
 type ClientWrappingAuthenticatorFunc[T any] func(ctx context.Context, innerClient *http.Client, user T) (*http.Client, error)
 
 // AuthorizeFunc is the signature of a function used to authorize a request.  If unable

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -30,6 +30,7 @@ const (
 	// ErrMissingAuthorizer is caused by internal configuration errors when evaluating authorization.
 	ErrMissingAuthorizer = AuthError("missing authenticator")
 
+	// ErrCannotAuthenticate indicates an authenticator could not provide credentials for the user. ClientSecurityGroups treats it as "try the next group" rather than a hard failure.````
 	ErrCouldntAuthenticate = AuthError("could not authenticate request")
 
 	// BasicAuthPrefix as defined by https://datatracker.ietf.org/doc/html/rfc7617

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -115,7 +115,7 @@ func HeaderClientAuth[T any](key string, fn ClientTokenAuthenticatorFunc[T]) Cli
 			return inner, err
 		}
 
-		r.Header.Add(key, token)
+		r.Header.Set(key, token)
 
 		return inner, nil
 	}
@@ -143,7 +143,7 @@ func BearerClientAuth[T any](key string, fn ClientTokenAuthenticatorFunc[T]) Cli
 			return inner, err
 		}
 
-		r.Header.Add(key, bearerAuthPrefix+token)
+		r.Header.Set(key, bearerAuthPrefix+token)
 
 		return inner, nil
 	}

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -112,7 +112,7 @@ func HeaderClientAuth[T any](key string, fn ClientTokenAuthenticatorFunc[T]) Cli
 	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
 		token, err := fn(r.Context(), user)
 		if err != nil {
-			return inner, err
+			return nil, err
 		}
 
 		r.Header.Set(key, token)
@@ -140,7 +140,7 @@ func BearerClientAuth[T any](key string, fn ClientTokenAuthenticatorFunc[T]) Cli
 	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
 		token, err := fn(r.Context(), user)
 		if err != nil {
-			return inner, err
+			return nil, err
 		}
 
 		r.Header.Set(key, bearerAuthPrefix+token)
@@ -166,7 +166,7 @@ func QueryClientAuth[T any](key string, fn ClientTokenAuthenticatorFunc[T]) Clie
 	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
 		token, err := fn(r.Context(), user)
 		if err != nil {
-			return inner, err
+			return nil, err
 		}
 
 		q := r.URL.Query()
@@ -210,7 +210,7 @@ func BasicClientAuth[T any](fn ClientBasicAuthenticatorFunc[T]) ClientAuthentica
 	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
 		username, password, err := fn(r.Context(), user)
 		if err != nil {
-			return inner, err
+			return nil, err
 		}
 
 		r.SetBasicAuth(username, password)
@@ -236,7 +236,7 @@ func CookieClientAuth[T any](fn ClientCookieAuthenticatorFunc[T]) ClientAuthenti
 	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
 		cookie, err := fn(r.Context(), user)
 		if err != nil {
-			return inner, err
+			return nil, err
 		}
 
 		if cookie != nil {
@@ -251,7 +251,7 @@ func WrapClientAuth[T any](fn ClientWrappingAuthenticatorFunc[T]) ClientAuthenti
 	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
 		client, err := fn(r.Context(), inner, user)
 		if err != nil {
-			return inner, err
+			return nil, err
 		}
 
 		return client, nil
@@ -342,7 +342,7 @@ func (s ClientSecurityGroup[T]) Auth(r *http.Request, innerClient *http.Client, 
 	for _, a := range s {
 		outerClient, err = a(modifiedReq, outerClient, u)
 		if err != nil {
-			return innerClient, err
+			return nil, err
 		}
 	}
 
@@ -364,11 +364,11 @@ func (s ClientSecurityGroups[T]) Auth(r *http.Request, innerClient *http.Client,
 		}
 
 		if err != nil {
-			return innerClient, err
+			return nil, err
 		}
 
 		return outerClient, nil
 	}
 
-	return innerClient, ErrCannotAuthenticate
+	return nil, ErrCannotAuthenticate
 }

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -213,8 +213,6 @@ func BasicClientAuth[T any](fn ClientBasicAuthenticatorFunc[T]) ClientAuthentica
 
 		r.SetBasicAuth(username, password)
 
-		r.BasicAuth()
-
 		return inner, nil
 	}
 }

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -355,14 +355,17 @@ type ClientSecurityGroups[T any] []ClientSecurityGroup[T]
 // Auth authenticates a client request with the first group that successfully authenticates, or returns
 // [ErrCouldntAuthenticate].
 func (s ClientSecurityGroups[T]) Auth(r *http.Request, innerClient *http.Client, u T) (*http.Client, error) {
-	var err error
 	for _, a := range s {
-		innerClient, err = a.Auth(r, innerClient, u)
+		outerClient, err := a.Auth(r, innerClient, u)
 		if errors.Is(err, ErrCouldntAuthenticate) {
 			continue
 		}
-		// return on success or true failure
-		return innerClient, err
+
+		if err != nil {
+			return innerClient, err
+		}
+
+		return outerClient, nil
 	}
 
 	return innerClient, ErrCouldntAuthenticate

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -52,6 +52,26 @@ type TokenAuthenticatorFunc[T any] func(ctx context.Context, token string) (T, e
 // BasicAuthenticatorFunc is the signature of a function used to authenticate a request given use user/pass.
 type BasicAuthenticatorFunc[T any] func(ctx context.Context, user, pass string) (T, error)
 
+// ClientAuthenticateFunc is the signature of a function used to add authentication to an outbound HTTP request.
+// It also has an opportunity to wrap the httpClient to be used for the request.
+type ClientAuthenticateFunc[T any] func(r *http.Request, innerClient *http.Client, user T) (*http.Client, error)
+
+// ClientTokenAuthenticatorFunc is the signature of a function used to determine the token that should be added
+// to an outbound HTTP request as authentication.
+type ClientTokenAuthenticatorFunc[T any] func(ctx context.Context, user T) (string, error)
+
+// ClientBasicAuthenticatorFunc is the signature of a function used to determine the username and password
+// that should be used to add Bsaic authentication to an outbound HTTP request.
+type ClientBasicAuthenticatorFunc[T any] func(ctx context.Context, user T) (string, string, error)
+
+// ClientCookieAuthenticatorFunc is the signature of a function used to determine the cookie
+// that should be added to an outbound HTTP request.
+type ClientCookieAuthenticatorFunc[T any] func(ctx context.Context, user T) (*http.Cookie, error)
+
+// ClientWrappingAuthenticatorFunc is the signature of a function used to wrap an http client so that it will
+// add authentication. This is intended for integration with x/oauth2.
+type ClientWrappingAuthenticatorFunc[T any] func(ctx context.Context, innerClient *http.Client, user T) (*http.Client, error)
+
 // AuthorizeFunc is the signature of a function used to authorize a request.  If unable
 // to authorize the user it returns an error.
 type AuthorizeFunc[T any] func(ctx context.Context, user T, scopes []string) error
@@ -77,6 +97,19 @@ func HeaderAuth[T any](key string, fn TokenAuthenticatorFunc[T]) AuthenticateFun
 	}
 }
 
+func HeaderClientAuth[T any](key string, fn ClientTokenAuthenticatorFunc[T]) ClientAuthenticateFunc[T] {
+	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
+		token, err := fn(r.Context(), user)
+		if err != nil {
+			return inner, err
+		}
+
+		r.Header.Add(key, token)
+
+		return inner, nil
+	}
+}
+
 const bearerAuthPrefix = "Bearer "
 
 func BearerAuth[T any](key string, tokenAuth TokenAuthenticatorFunc[T]) AuthenticateFunc[T] {
@@ -92,6 +125,19 @@ func BearerAuth[T any](key string, tokenAuth TokenAuthenticatorFunc[T]) Authenti
 	}
 }
 
+func BearerClientAuth[T any](key string, fn ClientTokenAuthenticatorFunc[T]) ClientAuthenticateFunc[T] {
+	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
+		token, err := fn(r.Context(), user)
+		if err != nil {
+			return inner, err
+		}
+
+		r.Header.Add(key, bearerAuthPrefix+token)
+
+		return inner, nil
+	}
+}
+
 func QueryAuth[T any](key string, fn TokenAuthenticatorFunc[T]) AuthenticateFunc[T] {
 	return func(r *http.Request) (T, error) {
 		var empty T
@@ -102,6 +148,22 @@ func QueryAuth[T any](key string, fn TokenAuthenticatorFunc[T]) AuthenticateFunc
 		}
 
 		return fn(r.Context(), token)
+	}
+}
+
+func QueryClientAuth[T any](key string, fn ClientTokenAuthenticatorFunc[T]) ClientAuthenticateFunc[T] {
+	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
+		token, err := fn(r.Context(), user)
+		if err != nil {
+			return inner, err
+		}
+
+		q := r.URL.Query()
+		q.Add(key, token)
+
+		r.URL.RawQuery = q.Encode()
+
+		return inner, nil
 	}
 }
 
@@ -133,6 +195,21 @@ func BasicAuth[T any](authFn BasicAuthenticatorFunc[T]) AuthenticateFunc[T] {
 	}
 }
 
+func BasicClientAuth[T any](fn ClientBasicAuthenticatorFunc[T]) ClientAuthenticateFunc[T] {
+	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
+		username, password, err := fn(r.Context(), user)
+		if err != nil {
+			return inner, err
+		}
+
+		r.SetBasicAuth(username, password)
+
+		r.BasicAuth()
+
+		return inner, nil
+	}
+}
+
 func CookieAuth[T any](key string, fn TokenAuthenticatorFunc[T]) AuthenticateFunc[T] {
 	return func(r *http.Request) (T, error) {
 		var empty T
@@ -143,6 +220,32 @@ func CookieAuth[T any](key string, fn TokenAuthenticatorFunc[T]) AuthenticateFun
 		}
 
 		return fn(r.Context(), cookie.Value)
+	}
+}
+
+func CookieClientAuth[T any](fn ClientCookieAuthenticatorFunc[T]) ClientAuthenticateFunc[T] {
+	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
+		cookie, err := fn(r.Context(), user)
+		if err != nil {
+			return inner, err
+		}
+
+		if cookie != nil {
+			r.AddCookie(cookie)
+		}
+
+		return inner, nil
+	}
+}
+
+func WrapClientAuth[T any](fn ClientWrappingAuthenticatorFunc[T]) ClientAuthenticateFunc[T] {
+	return func(r *http.Request, inner *http.Client, user T) (*http.Client, error) {
+		client, err := fn(r.Context(), inner, user)
+		if err != nil {
+			return inner, err
+		}
+
+		return client, nil
 	}
 }
 

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -78,7 +78,8 @@ type ClientCookieAuthenticatorFunc[T any] func(ctx context.Context, user T) (*ht
 // ClientWrappingAuthenticatorFunc is the signature of a function used to wrap an http client so that it will
 // add authentication. This is intended for integration with x/oauth2.  Should return [ErrCouldntAuthenticate] if the
 // method was not able to provide authorization for this user.
-type ClientWrappingAuthenticatorFunc[T any] func(ctx context.Context, innerClient *http.Client, user T) (*http.Client, error)
+type ClientWrappingAuthenticatorFunc[T any] func(
+	ctx context.Context, innerClient *http.Client, user T) (*http.Client, error)
 
 // AuthorizeFunc is the signature of a function used to authorize a request.  If unable
 // to authorize the user it returns an error.

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -30,8 +30,9 @@ const (
 	// ErrMissingAuthorizer is caused by internal configuration errors when evaluating authorization.
 	ErrMissingAuthorizer = AuthError("missing authenticator")
 
-	// ErrCannotAuthenticate indicates an authenticator could not provide credentials for the user. ClientSecurityGroups treats it as "try the next group" rather than a hard failure.````
-	ErrCouldntAuthenticate = AuthError("could not authenticate request")
+	// ErrCannotAuthenticate indicates an authenticator could not provide credentials for the user.
+	// ClientSecurityGroups treats it as "try the next group" rather than a hard failure.
+	ErrCannotAuthenticate = AuthError("could not authenticate request")
 
 	// BasicAuthPrefix as defined by https://datatracker.ietf.org/doc/html/rfc7617
 	BasicAuthPrefix = "Basic "
@@ -57,27 +58,27 @@ type TokenAuthenticatorFunc[T any] func(ctx context.Context, token string) (T, e
 type BasicAuthenticatorFunc[T any] func(ctx context.Context, user, pass string) (T, error)
 
 // ClientAuthenticateFunc is the signature of a function used to add authentication to an outbound HTTP request.
-// It also has an opportunity to wrap the httpClient to be used for the request. Should return [ErrCouldntAuthenticate]
+// It also has an opportunity to wrap the httpClient to be used for the request. Should return [ErrCannotAuthenticate]
 // if the method was not able to provide authorization for this user.
 type ClientAuthenticateFunc[T any] func(r *http.Request, innerClient *http.Client, user T) (*http.Client, error)
 
 // ClientTokenAuthenticatorFunc is the signature of a function used to determine the token that should be added
-// to an outbound HTTP request as authentication. Should return [ErrCouldntAuthenticate] if the method was not able to
+// to an outbound HTTP request as authentication. Should return [ErrCannotAuthenticate] if the method was not able to
 // provide authorization for this user.
 type ClientTokenAuthenticatorFunc[T any] func(ctx context.Context, user T) (string, error)
 
 // ClientBasicAuthenticatorFunc is the signature of a function used to determine the username and password
-// that should be used to add Basic authentication to an outbound HTTP request. Should return [ErrCouldntAuthenticate]
+// that should be used to add Basic authentication to an outbound HTTP request. Should return [ErrCannotAuthenticate]
 // if the method was not able to provide authorization for this user.
 type ClientBasicAuthenticatorFunc[T any] func(ctx context.Context, user T) (string, string, error)
 
 // ClientCookieAuthenticatorFunc is the signature of a function used to determine the cookie that should be added
-// to an outbound HTTP request.  Should return [ErrCouldntAuthenticate] if the method was not able to provide
+// to an outbound HTTP request.  Should return [ErrCannotAuthenticate] if the method was not able to provide
 // authorization for this user.
 type ClientCookieAuthenticatorFunc[T any] func(ctx context.Context, user T) (*http.Cookie, error)
 
 // ClientWrappingAuthenticatorFunc is the signature of a function used to wrap an http client so that it will
-// add authentication. This is intended for integration with x/oauth2.  Should return [ErrCouldntAuthenticate] if the
+// add authentication. This is intended for integration with x/oauth2.  Should return [ErrCannotAuthenticate] if the
 // method was not able to provide authorization for this user.
 type ClientWrappingAuthenticatorFunc[T any] func(
 	ctx context.Context, innerClient *http.Client, user T) (*http.Client, error)
@@ -354,11 +355,11 @@ func (s ClientSecurityGroup[T]) Auth(r *http.Request, innerClient *http.Client, 
 type ClientSecurityGroups[T any] []ClientSecurityGroup[T]
 
 // Auth authenticates a client request with the first group that successfully authenticates, or returns
-// [ErrCouldntAuthenticate].
+// [ErrCannotAuthenticate].
 func (s ClientSecurityGroups[T]) Auth(r *http.Request, innerClient *http.Client, u T) (*http.Client, error) {
 	for _, a := range s {
 		outerClient, err := a.Auth(r, innerClient, u)
-		if errors.Is(err, ErrCouldntAuthenticate) {
+		if errors.Is(err, ErrCannotAuthenticate) {
 			continue
 		}
 
@@ -369,5 +370,5 @@ func (s ClientSecurityGroups[T]) Auth(r *http.Request, innerClient *http.Client,
 		return outerClient, nil
 	}
 
-	return innerClient, ErrCouldntAuthenticate
+	return innerClient, ErrCannotAuthenticate
 }

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -67,7 +67,7 @@ type ClientAuthenticateFunc[T any] func(r *http.Request, innerClient *http.Clien
 type ClientTokenAuthenticatorFunc[T any] func(ctx context.Context, user T) (string, error)
 
 // ClientBasicAuthenticatorFunc is the signature of a function used to determine the username and password
-// that should be used to add Bsaic authentication to an outbound HTTP request. Should return [ErrCouldntAuthenticate]
+// that should be used to add Basic authentication to an outbound HTTP request. Should return [ErrCouldntAuthenticate]
 // if the method was not able to provide authorization for this user.
 type ClientBasicAuthenticatorFunc[T any] func(ctx context.Context, user T) (string, string, error)
 

--- a/httputil/auth.go
+++ b/httputil/auth.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -326,4 +327,44 @@ func (s SecurityGroups[T]) Auth(r *http.Request) (T, error) {
 	}
 
 	return user, err
+}
+
+// ClientSecurityGroup are valid if all the authenticate functions succeed.
+type ClientSecurityGroup[T any] []ClientAuthenticateFunc[T]
+
+// Auth authenticates a client request with all the authhenticate functions or returns the first failure.
+func (s ClientSecurityGroup[T]) Auth(r *http.Request, innerClient *http.Client, u T) (*http.Client, error) {
+	var err error
+	outerClient := innerClient
+	modifiedReq := r.Clone(r.Context())
+
+	for _, a := range s {
+		outerClient, err = a(modifiedReq, outerClient, u)
+		if err != nil {
+			return innerClient, err
+		}
+	}
+
+	*r = *modifiedReq
+
+	return outerClient, nil
+}
+
+// ClientSecurityGroups are valid if ANY group is valid.
+type ClientSecurityGroups[T any] []ClientSecurityGroup[T]
+
+// Auth authenticates a client request with the first group that successfully authenticates, or returns
+// [ErrCouldntAuthenticate].
+func (s ClientSecurityGroups[T]) Auth(r *http.Request, innerClient *http.Client, u T) (*http.Client, error) {
+	var err error
+	for _, a := range s {
+		innerClient, err = a.Auth(r, innerClient, u)
+		if errors.Is(err, ErrCouldntAuthenticate) {
+			continue
+		}
+		// return on success or true failure
+		return innerClient, err
+	}
+
+	return innerClient, ErrCouldntAuthenticate
 }

--- a/httputil/auth_test.go
+++ b/httputil/auth_test.go
@@ -340,7 +340,7 @@ func strClientAuth(_ context.Context, user string) (string, error) {
 		return "", ErrBad
 	}
 
-	return "", httputil.ErrCouldntAuthenticate
+	return "", httputil.ErrCannotAuthenticate
 }
 
 func failClientAuth(_ context.Context, _ string) (string, error) {
@@ -353,7 +353,7 @@ func onlyUser(name string) httputil.ClientTokenAuthenticatorFunc[string] {
 			return "token", nil
 		}
 
-		return "", httputil.ErrCouldntAuthenticate
+		return "", httputil.ErrCannotAuthenticate
 	}
 }
 
@@ -365,7 +365,7 @@ func basicClientAuth(_ context.Context, user string) (string, string, error) {
 		return "", "", ErrBad
 	}
 
-	return "", "", httputil.ErrCouldntAuthenticate
+	return "", "", httputil.ErrCannotAuthenticate
 }
 
 func cookieClientAuth(_ context.Context, user string) (*http.Cookie, error) {
@@ -378,7 +378,7 @@ func cookieClientAuth(_ context.Context, user string) (*http.Cookie, error) {
 		return nil, ErrBad
 	}
 
-	return nil, httputil.ErrCouldntAuthenticate
+	return nil, httputil.ErrCannotAuthenticate
 }
 
 func TestHeaderClientAuth(t *testing.T) {
@@ -392,7 +392,7 @@ func TestHeaderClientAuth(t *testing.T) {
 	tests := []testCase{
 		{"Good", "X-Auth", "good", "token", nil},
 		{"Bad", "X-Auth", "bad", "", ErrBad},
-		{"Couldnt", "X-Auth", "other", "", httputil.ErrCouldntAuthenticate},
+		{"Couldnt", "X-Auth", "other", "", httputil.ErrCannotAuthenticate},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -423,7 +423,7 @@ func TestBearerClientAuth(t *testing.T) {
 	tests := []testCase{
 		{"Good", "Authorization", "good", "Bearer token", nil},
 		{"Bad", "Authorization", "bad", "", ErrBad},
-		{"Couldnt", "Authorization", "other", "", httputil.ErrCouldntAuthenticate},
+		{"Couldnt", "Authorization", "other", "", httputil.ErrCannotAuthenticate},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -454,7 +454,7 @@ func TestQueryClientAuth(t *testing.T) {
 	tests := []testCase{
 		{"Good", "auth", "good", "token", nil},
 		{"Bad", "auth", "bad", "", ErrBad},
-		{"Couldnt", "auth", "other", "", httputil.ErrCouldntAuthenticate},
+		{"Couldnt", "auth", "other", "", httputil.ErrCannotAuthenticate},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -485,7 +485,7 @@ func TestBasicClientAuth(t *testing.T) {
 	tests := []testCase{
 		{"Good", "good", "u", "p", nil},
 		{"Bad", "bad", "", "", ErrBad},
-		{"Couldnt", "other", "", "", httputil.ErrCouldntAuthenticate},
+		{"Couldnt", "other", "", "", httputil.ErrCannotAuthenticate},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -524,7 +524,7 @@ func TestCookieClientAuth(t *testing.T) {
 		{"Good", "good", "token", nil},
 		{"Nil", "nil", "", nil},
 		{"Bad", "bad", "", ErrBad},
-		{"Couldnt", "other", "", httputil.ErrCouldntAuthenticate},
+		{"Couldnt", "other", "", httputil.ErrCannotAuthenticate},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -563,7 +563,7 @@ func TestWrapClientAuth(t *testing.T) {
 			return nil, ErrBad
 		}
 
-		return in, httputil.ErrCouldntAuthenticate
+		return in, httputil.ErrCannotAuthenticate
 	}
 
 	type testCase struct {
@@ -575,7 +575,7 @@ func TestWrapClientAuth(t *testing.T) {
 	tests := []testCase{
 		{"good", "good", wrapped, nil},
 		{"bad", "bad", inner, ErrBad},
-		{"couldnt", "other", inner, httputil.ErrCouldntAuthenticate},
+		{"couldnt", "other", inner, httputil.ErrCannotAuthenticate},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -663,7 +663,7 @@ func TestClientSecurityGroups_Auth(t *testing.T) {
 	tests := []testCase{
 		{"first group succeeds", groups, "a", "token", "", nil},
 		{"falls through to a later group", groups, "b", "", "token", nil},
-		{"none can authenticate", groups, "c", "", "", httputil.ErrCouldntAuthenticate},
+		{"none can authenticate", groups, "c", "", "", httputil.ErrCannotAuthenticate},
 		{"true failure stops iteration", failing, "b", "", "", ErrBad},
 	}
 	for _, tt := range tests {

--- a/httputil/auth_test.go
+++ b/httputil/auth_test.go
@@ -404,9 +404,9 @@ func TestHeaderClientAuth(t *testing.T) {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
 				require.NoError(t, err)
+				assert.Same(t, inner, got)
 			}
 
-			assert.Same(t, inner, got)
 			assert.Equal(t, tt.want, r.Header.Get(tt.key))
 		})
 	}
@@ -435,9 +435,9 @@ func TestBearerClientAuth(t *testing.T) {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
 				require.NoError(t, err)
+				assert.Same(t, inner, got)
 			}
 
-			assert.Same(t, inner, got)
 			assert.Equal(t, tt.want, r.Header.Get(tt.key))
 		})
 	}
@@ -466,9 +466,9 @@ func TestQueryClientAuth(t *testing.T) {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
 				require.NoError(t, err)
+				assert.Same(t, inner, got)
 			}
 
-			assert.Same(t, inner, got)
 			assert.Equal(t, tt.want, r.URL.Query().Get(tt.key))
 		})
 	}
@@ -497,9 +497,8 @@ func TestBasicClientAuth(t *testing.T) {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
 				require.NoError(t, err)
+				assert.Same(t, inner, got)
 			}
-
-			assert.Same(t, inner, got)
 
 			u, p, ok := r.BasicAuth()
 			if tt.err == nil {
@@ -536,9 +535,8 @@ func TestCookieClientAuth(t *testing.T) {
 				assert.ErrorIs(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
+				assert.Same(t, inner, got)
 			}
-
-			assert.Same(t, inner, got)
 
 			cookie, cookieErr := r.Cookie("session")
 			if tt.want != "" {
@@ -586,9 +584,8 @@ func TestWrapClientAuth(t *testing.T) {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
 				require.NoError(t, err)
+				assert.Same(t, tt.want, got)
 			}
-
-			assert.Same(t, tt.want, got)
 		})
 	}
 }
@@ -631,9 +628,9 @@ func TestClientSecurityGroup_Auth(t *testing.T) {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
 				require.NoError(t, err)
+				assert.Same(t, inner, got)
 			}
 
-			assert.Same(t, inner, got)
 			assert.Equal(t, tt.wantA, r.Header.Get("X-A"))
 			assert.Equal(t, tt.wantB, r.Header.Get("X-B"))
 		})
@@ -675,9 +672,9 @@ func TestClientSecurityGroups_Auth(t *testing.T) {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
 				require.NoError(t, err)
+				assert.Same(t, inner, got)
 			}
 
-			assert.Same(t, inner, got)
 			assert.Equal(t, tt.wantA, r.Header.Get("X-A"))
 			assert.Equal(t, tt.wantB, r.Header.Get("X-B"))
 		})

--- a/httputil/auth_test.go
+++ b/httputil/auth_test.go
@@ -331,3 +331,355 @@ func TestBasicAuth(t *testing.T) {
 		})
 	}
 }
+
+func strClientAuth(_ context.Context, user string) (string, error) {
+	switch user {
+	case "good":
+		return "token", nil
+	case "bad":
+		return "", ErrBad
+	}
+
+	return "", httputil.ErrCouldntAuthenticate
+}
+
+func failClientAuth(_ context.Context, _ string) (string, error) {
+	return "", ErrBad
+}
+
+func onlyUser(name string) httputil.ClientTokenAuthenticatorFunc[string] {
+	return func(_ context.Context, user string) (string, error) {
+		if user == name {
+			return "token", nil
+		}
+
+		return "", httputil.ErrCouldntAuthenticate
+	}
+}
+
+func basicClientAuth(_ context.Context, user string) (string, string, error) {
+	switch user {
+	case "good":
+		return "u", "p", nil
+	case "bad":
+		return "", "", ErrBad
+	}
+
+	return "", "", httputil.ErrCouldntAuthenticate
+}
+
+func cookieClientAuth(_ context.Context, user string) (*http.Cookie, error) {
+	switch user {
+	case "good":
+		return &http.Cookie{Name: "session", Value: "token"}, nil
+	case "nil":
+		return nil, nil
+	case "bad":
+		return nil, ErrBad
+	}
+
+	return nil, httputil.ErrCouldntAuthenticate
+}
+
+func TestHeaderClientAuth(t *testing.T) {
+	type testCase struct {
+		name string
+		key  string
+		user string
+		want string
+		err  error
+	}
+	tests := []testCase{
+		{"Good", "X-Auth", "good", "token", nil},
+		{"Bad", "X-Auth", "bad", "", ErrBad},
+		{"Couldnt", "X-Auth", "other", "", httputil.ErrCouldntAuthenticate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("FOO", "/asdf", nil)
+			inner := &http.Client{}
+
+			got, err := httputil.HeaderClientAuth(tt.key, strClientAuth)(r, inner, tt.user)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Same(t, inner, got)
+			assert.Equal(t, tt.want, r.Header.Get(tt.key))
+		})
+	}
+}
+
+func TestBearerClientAuth(t *testing.T) {
+	type testCase struct {
+		name string
+		key  string
+		user string
+		want string
+		err  error
+	}
+	tests := []testCase{
+		{"Good", "Authorization", "good", "Bearer token", nil},
+		{"Bad", "Authorization", "bad", "", ErrBad},
+		{"Couldnt", "Authorization", "other", "", httputil.ErrCouldntAuthenticate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("FOO", "/asdf", nil)
+			inner := &http.Client{}
+
+			got, err := httputil.BearerClientAuth(tt.key, strClientAuth)(r, inner, tt.user)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Same(t, inner, got)
+			assert.Equal(t, tt.want, r.Header.Get(tt.key))
+		})
+	}
+}
+
+func TestQueryClientAuth(t *testing.T) {
+	type testCase struct {
+		name string
+		key  string
+		user string
+		want string
+		err  error
+	}
+	tests := []testCase{
+		{"Good", "auth", "good", "token", nil},
+		{"Bad", "auth", "bad", "", ErrBad},
+		{"Couldnt", "auth", "other", "", httputil.ErrCouldntAuthenticate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("FOO", "/asdf", nil)
+			inner := &http.Client{}
+
+			got, err := httputil.QueryClientAuth(tt.key, strClientAuth)(r, inner, tt.user)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Same(t, inner, got)
+			assert.Equal(t, tt.want, r.URL.Query().Get(tt.key))
+		})
+	}
+}
+
+func TestBasicClientAuth(t *testing.T) {
+	type testCase struct {
+		name     string
+		user     string
+		wantUser string
+		wantPass string
+		err      error
+	}
+	tests := []testCase{
+		{"Good", "good", "u", "p", nil},
+		{"Bad", "bad", "", "", ErrBad},
+		{"Couldnt", "other", "", "", httputil.ErrCouldntAuthenticate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("FOO", "/asdf", nil)
+			inner := &http.Client{}
+
+			got, err := httputil.BasicClientAuth(basicClientAuth)(r, inner, tt.user)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Same(t, inner, got)
+
+			u, p, ok := r.BasicAuth()
+			if tt.err == nil {
+				assert.True(t, ok)
+				assert.Equal(t, tt.wantUser, u)
+				assert.Equal(t, tt.wantPass, p)
+			} else {
+				assert.False(t, ok)
+			}
+		})
+	}
+}
+
+func TestCookieClientAuth(t *testing.T) {
+	type testCase struct {
+		name    string
+		user    string
+		want    string
+		wantErr error
+	}
+	tests := []testCase{
+		{"Good", "good", "token", nil},
+		{"Nil", "nil", "", nil},
+		{"Bad", "bad", "", ErrBad},
+		{"Couldnt", "other", "", httputil.ErrCouldntAuthenticate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("FOO", "/asdf", nil)
+			inner := &http.Client{}
+
+			got, err := httputil.CookieClientAuth(cookieClientAuth)(r, inner, tt.user)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Same(t, inner, got)
+
+			cookie, cookieErr := r.Cookie("session")
+			if tt.want != "" {
+				require.NoError(t, cookieErr)
+				assert.Equal(t, tt.want, cookie.Value)
+			} else {
+				assert.ErrorIs(t, cookieErr, http.ErrNoCookie)
+			}
+		})
+	}
+}
+
+func TestWrapClientAuth(t *testing.T) {
+	inner := &http.Client{}
+	wrapped := &http.Client{}
+
+	fn := func(_ context.Context, in *http.Client, user string) (*http.Client, error) {
+		switch user {
+		case "good":
+			return wrapped, nil
+		case "bad":
+			return nil, ErrBad
+		}
+
+		return in, httputil.ErrCouldntAuthenticate
+	}
+
+	type testCase struct {
+		name string
+		user string
+		want *http.Client
+		err  error
+	}
+	tests := []testCase{
+		{"good", "good", wrapped, nil},
+		{"bad", "bad", inner, ErrBad},
+		{"couldnt", "other", inner, httputil.ErrCouldntAuthenticate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("FOO", "/asdf", nil)
+
+			got, err := httputil.WrapClientAuth(fn)(r, inner, tt.user)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Same(t, tt.want, got)
+		})
+	}
+}
+
+func TestClientSecurityGroup_Auth(t *testing.T) {
+	inner := &http.Client{}
+
+	type testCase struct {
+		name  string
+		g     httputil.ClientSecurityGroup[string]
+		user  string
+		wantA string
+		wantB string
+		err   error
+	}
+	tests := []testCase{
+		{
+			"all succeed",
+			httputil.ClientSecurityGroup[string]{
+				httputil.HeaderClientAuth("X-A", strClientAuth),
+				httputil.HeaderClientAuth("X-B", strClientAuth),
+			},
+			"good", "token", "token", nil,
+		},
+		{
+			"failure returns inner and leaves request unmodified",
+			httputil.ClientSecurityGroup[string]{
+				httputil.HeaderClientAuth("X-A", strClientAuth),
+				httputil.HeaderClientAuth("X-B", failClientAuth),
+			},
+			"good", "", "", ErrBad,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("FOO", "/asdf", nil)
+
+			got, err := tt.g.Auth(r, inner, tt.user)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Same(t, inner, got)
+			assert.Equal(t, tt.wantA, r.Header.Get("X-A"))
+			assert.Equal(t, tt.wantB, r.Header.Get("X-B"))
+		})
+	}
+}
+
+func TestClientSecurityGroups_Auth(t *testing.T) {
+	inner := &http.Client{}
+
+	groups := httputil.ClientSecurityGroups[string]{
+		{httputil.HeaderClientAuth("X-A", onlyUser("a"))},
+		{httputil.HeaderClientAuth("X-B", onlyUser("b"))},
+	}
+	failing := httputil.ClientSecurityGroups[string]{
+		{httputil.HeaderClientAuth("X-A", failClientAuth)},
+		{httputil.HeaderClientAuth("X-B", onlyUser("b"))},
+	}
+
+	type testCase struct {
+		name  string
+		s     httputil.ClientSecurityGroups[string]
+		user  string
+		wantA string
+		wantB string
+		err   error
+	}
+	tests := []testCase{
+		{"first group succeeds", groups, "a", "token", "", nil},
+		{"falls through to a later group", groups, "b", "", "token", nil},
+		{"none can authenticate", groups, "c", "", "", httputil.ErrCouldntAuthenticate},
+		{"true failure stops iteration", failing, "b", "", "", ErrBad},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("FOO", "/asdf", nil)
+
+			got, err := tt.s.Auth(r, inner, tt.user)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Same(t, inner, got)
+			assert.Equal(t, tt.wantA, r.Header.Get("X-A"))
+			assert.Equal(t, tt.wantB, r.Header.Get("X-B"))
+		})
+	}
+}

--- a/httputil/client.go
+++ b/httputil/client.go
@@ -1,0 +1,16 @@
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type UnexpectedResponseError struct {
+	Resp *http.Response
+	URL  string
+	Body []byte
+}
+
+func (e UnexpectedResponseError) Error() string {
+	return fmt.Sprintf("url: %q, status: %d, body: %q: unexpected response status code", e.URL, e.Resp.StatusCode, e.Body)
+}

--- a/httputil/client.go
+++ b/httputil/client.go
@@ -3,6 +3,7 @@ package httputil
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 type UnexpectedResponseError struct {
@@ -12,5 +13,10 @@ type UnexpectedResponseError struct {
 }
 
 func (e UnexpectedResponseError) Error() string {
-	return fmt.Sprintf("url: %q, status: %d, body: %q: unexpected response status code", e.URL, e.Resp.StatusCode, e.Body)
+	status := "unknown"
+	if e.Resp != nil {
+		status = strconv.Itoa(e.Resp.StatusCode)
+	}
+
+	return fmt.Sprintf("url: %q, status: %s, body: %q: unexpected response status code", e.URL, status, e.Body)
 }

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -1,0 +1,22 @@
+package httputil_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bir/iken/httputil"
+)
+
+func TestUnexpectedResponseError_Error(t *testing.T) {
+	err := httputil.UnexpectedResponseError{
+		Resp: &http.Response{StatusCode: http.StatusNotFound},
+		URL:  "http://example.com/foo",
+		Body: []byte("not found"),
+	}
+
+	assert.Equal(t,
+		`url: "http://example.com/foo", status: 404, body: "not found": unexpected response status code`,
+		err.Error())
+}

--- a/httputil/client_test.go
+++ b/httputil/client_test.go
@@ -20,3 +20,14 @@ func TestUnexpectedResponseError_Error(t *testing.T) {
 		`url: "http://example.com/foo", status: 404, body: "not found": unexpected response status code`,
 		err.Error())
 }
+
+func TestUnexpectedResponseError_Error_NilResp(t *testing.T) {
+	err := httputil.UnexpectedResponseError{
+		URL:  "http://example.com/foo",
+		Body: []byte("not found"),
+	}
+
+	assert.Equal(t,
+		`url: "http://example.com/foo", status: unknown, body: "not found": unexpected response status code`,
+		err.Error())
+}


### PR DESCRIPTION
Motivation: I am [adding](https://github.com/gofoji/foji/pull/71) a client generator to `gofoji/foji`. To maintain consistency with the Foji handler generator, this client should handle HTTP details and provide a simple go interface. Akin to handler generation, users will supply a auth class and helpers to convert the auth class to the required token/username/password etc. To match the handler generation, this will
use common types and helper funcs in `iken`. Simplicity also necessitates an error type for non-2xx HTTP responses, which must be in a library Foji clients import so that it is uniform across clients.

Changes: 

1. Add `UnexpectedResponseError`. This error allows wrappers of `http.Client` to signal non-successful HTTP responses as an error. It preserves the initial request URL (resp.Req.URL only shows the last URL in a series of redirects) for clear error messages. It preserves the body both for error messages and also to allow inspection for error handling.

2. Add `ClientAuthenticateFunc`, the basic type for a function that adds authorization to an outbound request. Unlike `AuthenticateFunc`, this also allows the function to update the `http.Client`. This allows using `x/oauth2`, which requires you to use a client they generate. This client does additional oauth2 refreshes when required, so cannot be replicated as a mere `http.Request` change.

3. Add `*ClientAuth` functions for Bearer auth, header auth, query auth, basic auth, cookie auth and "http client wrapping" auth. These do the actual work of setting the request/client for a specific request.

4. Add `Client*AuthenticatorFunc` for tokens, basic auth, cookie auth and `http.Client` wrapping. These will be what the application is expected to supply to the foji generated client, and represent how to go from the user object to the credentials the *ClientAuth functions need.

5. Add `ClientSecurityGroup` and `ClientSecurityGroups` to provide the logic for the client to send the authentication for the first security group that has all its authenticators succeed.